### PR TITLE
Customize udp port via IpmiClientConfiguration

### DIFF
--- a/src/main/java/org/metricshub/ipmi/client/IpmiClientConfiguration.java
+++ b/src/main/java/org/metricshub/ipmi/client/IpmiClientConfiguration.java
@@ -1,5 +1,7 @@
 package org.metricshub.ipmi.client;
 
+import org.metricshub.ipmi.core.common.Constants;
+
 /*-
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
  * IPMI Java Client
@@ -34,6 +36,7 @@ public class IpmiClientConfiguration {
 	private char[] password;
 	private byte[] bmcKey;
 	private boolean skipAuth;
+	private int port = Constants.IPMI_PORT;
 	private long timeout;
 	private long pingPeriod = -1;
 
@@ -55,6 +58,23 @@ public class IpmiClientConfiguration {
 		this.bmcKey = bmcKey;
 		this.skipAuth = skipAuth;
 		this.timeout = timeout;
+	}
+
+	/**
+	 * Instantiates a new {@link IpmiClientConfiguration} in order to query the IPMI host.
+	 * 
+	 * @param hostname IP Address or host name of the remote IPMI host.
+	 * @param port UDP port number of the remote IPMI host.
+	 * @param username Name used to establish the connection with the host via the IPMI protocol.
+	 * @param password Password used to establish the connection with the host via the IPMI protocol.
+	 * @param bmcKey   The key that should be provided if the two-key authentication is enabled, null otherwise.
+	 * @param skipAuth Whether the client should skip authentication
+	 * @param timeout  Timeout used for each IPMI request.
+	 */
+	public IpmiClientConfiguration(String hostname, int port, String username, char[] password,
+			byte[] bmcKey, boolean skipAuth, long timeout) {
+		this(hostname, username, password, bmcKey, skipAuth, timeout);
+		this.port = port;
 	}
 
 	/**
@@ -91,6 +111,24 @@ public class IpmiClientConfiguration {
 	 */
 	public void setHostname(String hostname) {
 		this.hostname = hostname;
+	}
+
+	/**
+	 * Returns the UDP port number of the remote IPMI host.
+	 * 
+	 * @return UDP port number of the remote IPMI host.
+	 */
+	public int getPort() {
+		return port;
+	}
+
+	/**
+	 * Sets the UDP port number of the remote IPMI host.
+	 * 
+	 * @param port UDP port number of the remote IPMI host.
+	 */
+	public void setPort(int port) {
+		this.port = port;
 	}
 
 	/**

--- a/src/main/java/org/metricshub/ipmi/client/runner/AbstractIpmiRunner.java
+++ b/src/main/java/org/metricshub/ipmi/client/runner/AbstractIpmiRunner.java
@@ -101,7 +101,7 @@ public abstract class AbstractIpmiRunner<T> implements AutoCloseable, Callable<T
 			authenticate();
 		} else {
 			handle = connector.createConnection(InetAddress.getByName(ipmiConfiguration.getHostname()),
-					Connection.getDefaultCipherSuite(), PrivilegeLevel.User);
+					ipmiConfiguration.getPort(), Connection.getDefaultCipherSuite(), PrivilegeLevel.User);
 		}
 
 		// Start the session, provide user name and password, and optionally the
@@ -122,7 +122,8 @@ public abstract class AbstractIpmiRunner<T> implements AutoCloseable, Callable<T
 		// the handle will be needed to identify it among other connections
 		// (target IP address isn't enough, since we can handle multiple
 		// connections to the same host)
-		handle = connector.createConnection(InetAddress.getByName(ipmiConfiguration.getHostname()));
+		handle = connector.createConnection(InetAddress.getByName(ipmiConfiguration.getHostname()),
+				ipmiConfiguration.getPort());
 
 		// Get available cipher suites list via getAvailableCipherSuites and
 		// pick one of them that will be used further in the session.


### PR DESCRIPTION
Introduce the new interfaces to set UDP port different from the default one(UDP). This has been supported by the underlying implementations but has not been possible when connection information is passed down by IpmiClientConfiguration .